### PR TITLE
Add support for <colgroup>, <tfoot>,  and more table and cell attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,8 +2,8 @@
 
         - <table> element:
 
-           - add direct specification of 'id' and 'class' attributes
-             via the 'id' and 'class' parameters.
+           - add direct specification of 'id', 'class', and 'style'
+             attributes via the 'id', 'class', and 'style' parameters.
 
            - Add generic attributes via the 'attr' parameter
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,21 @@
+
+
+        - <table> element:
+
+           - add direct specification of 'id' and 'class' attributes
+             via the 'id' and 'class' parameters.
+
+           - Add generic attributes via the 'attr' parameter
+
+           - add <colgroup> and <tfoot> elements
+
+        - table cells:
+
+           - Add 'class', 'header', 'id', 'scope', 'style' attributes
+
+           - allow specification of the type of cell (e.g. 'th' or 'td')
+
+
 0.010   2023-05-22  Released-By: PERLANCAR; Urgency: medium
 
         - [bugfix] Fix some bugs with placement of <tbody> tag (thanks DJERIUS).

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -27,8 +27,7 @@ sub table {
     my @table;
 
     my %attr = %{ delete($params{attr}) // {} };
-    $attr{id} = delete $params{id};
-    $attr{class} = delete $params{class};
+    $attr{$_} = delete $params{$_} for qw( id class style );
 
     my $attr = keys %attr
       ?  join q{ }, '', map { qq{$_="$attr{$_}"} } grep defined( $attr{$_} ), keys %attr
@@ -363,6 +362,10 @@ Optional. Scalar.  The table tag's I<id> attribute.
 =item * class
 
 Optional. Scalar.  The table tag's I<class> attribute.
+
+=item * style
+
+Optional. Scalar.  The table tag's I<style> attribute.
 
 
 =back

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -26,7 +26,11 @@ sub table {
     # here we go...
     my @table;
 
-    push @table, "<table>\n";
+    my $attr =defined $params{attr}
+      ?  join q{ }, '', map { qq{$_="$params{attr}{$_}"} } keys %{$params{attr}}
+      : '';
+
+    push @table, "<table$attr>\n";
 
     if (defined $params{caption}) {
         push @table, "<caption>"._encode($params{caption})."</caption>\n";
@@ -202,6 +206,10 @@ table caption.
 Optional. Integer. Default 0. Whether we should add header row(s) (rows inside
 C<< <thead> >> instead of C<< <tbody> >>). Support multiple header rows; you can
 set this argument to an integer larger than 1.
+
+=item * attr
+
+Optional. Hash.  The hash elements are added as attributes to the C<table> tag.
 
 =back
 

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -36,6 +36,27 @@ sub table {
         push @table, "<caption>"._encode($params{caption})."</caption>\n";
     }
 
+    if ( defined $params{colgroup} ) {
+        push @table, "<colgroup>\n";
+
+        for my $col ( @{ $params{colgroup} } ) {
+
+            my @tag = '<col';
+            if ( defined $col ) {
+                if ( 'HASH' eq ref $col ) {
+                    push @tag, qq{$_="$col->{$_}"} for keys %{$col};
+                }
+                else {
+                    push @tag, $col;
+                }
+            }
+            push @tag, '/>';
+            push @table, join( q{ }, @tag ), "\n";
+        }
+
+        push @table, "</colgroup>\n";
+    }
+
     # then the data
     my $header_row   = $params{header_row} // 0;
     my $needs_thead = !!$header_row;
@@ -210,6 +231,28 @@ set this argument to an integer larger than 1.
 =item * attr
 
 Optional. Hash.  The hash elements are added as attributes to the C<table> tag.
+
+=item * colgroup
+
+Optional. An array of scalars or hashes which define a C<colgroup> block.
+
+The array should contain one entry per column or per span of
+columns. If an entry is C<undef>, or an empty hash, then an empty C<col>
+tag will be added.
+
+Hashes are translated into tag attributes; scalars are put into the C<col>
+tag as is.  For example,
+
+  colgroup => [ undef, {}, q{span="2"}, { class => 'batman' } ]
+
+results in
+
+  <colgroup>
+  <col/>
+  <col/>
+  <col span="2" />
+  <col class="batman" />
+  </colgroup>
 
 =back
 

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -184,6 +184,11 @@ sub table {
                       unless $coltag eq 'th';
                     $attr .= ' scope="' . $cell->{scope} . '"'
                 }
+
+                # cleaner if in a loop, but that might slow things down
+                $attr .= ' class="' . $cell->{class} . '"' if defined $cell->{class};
+                $attr .= ' headers="' . $cell->{headers} . '"' if defined $cell->{headers};
+                $attr .= ' id="' . $cell->{id} . '"' if defined $cell->{id};
                 $attr .= ' style="' . $cell->{style} . '"' if defined $cell->{style};
             }
             else {
@@ -198,7 +203,6 @@ sub table {
           "<tr". ( $bottom_border // '' ) .">",
           @row,
           "</tr>\n";
-
     }
 
     push @table, "</thead>\n" if $needs_thead_close;
@@ -264,11 +268,13 @@ The C<table> function understands these arguments, which are passed as a hash.
 
 =item * rows
 
-Required. Array of array of (scalars or hashrefs). One or more rows of data,
-where each row is an array reference. And each array element is a string (cell
-content) or hashref (with key C<text> to contain the cell text or C<raw_html> to
-contain the cell's raw HTML which won't be escaped further), and optionally
-other attributes: C<rowspan>, C<colspan>, C<align>, C<style>, C<scope>, C<bottom_border>, C<tag>).
+Required. Array of array of (scalars or hashrefs). One or more rows of
+data, where each row is an array reference. And each array element is
+a string (cell content) or hashref (with key C<text> to contain the
+cell text or C<raw_html> to contain the cell's raw HTML which won't be
+escaped further), and optionally other attributes: C<align>,
+C<bottom_border>, C<class>, C<colspan>, C<headers>, C<id>, C<rowspan>,
+C<scope>, C<style>, C<tag>).
 
 The C<tag> attribute specifies the tag to use for that cell.  For example,
 

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -27,7 +27,10 @@ sub table {
     my @table;
 
     my %attr = %{ delete($params{attr}) // {} };
-    $attr{$_} = delete $params{$_} for qw( id class style );
+    {
+        my @direct_attr = grep exists $params{$_}, qw( id class style );
+        $attr{@direct_attr} = delete @params{@direct_attr};
+    }
 
     my $attr = keys %attr
       ?  join q{ }, '', map { qq{$_="$attr{$_}"} } grep defined( $attr{$_} ), keys %attr

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -9,11 +9,6 @@ use warnings;
 # DIST
 # VERSION
 
-sub _croak {
-    require Carp;
-    goto &Carp::croak;
-}
-
 sub _encode {
     state $load = do { require HTML::Entities };
     HTML::Entities::encode_entities(shift);
@@ -68,7 +63,7 @@ sub table {
     my $footer_row   = delete $params{footer_row} // 0;
 
     # check for unrecognized options
-    _croak( "unrecognized options: ", join q{, }, sort keys %params )
+    die( "unrecognized options: ", join q{, }, sort keys %params )
       if keys %params;
 
     my $footer_row_start;
@@ -192,7 +187,7 @@ sub table {
                 $celltag = $cell->{tag} if defined $cell->{tag};
 
                 if ( defined $cell->{scope} ) {
-                    _croak( "'scope' attribute is only valid in header cells" )
+                    die( "'scope' attribute is only valid in header cells" )
                       unless $coltag eq 'th';
                     $attr .= ' scope="' . $cell->{scope} . '"'
                 }

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -27,6 +27,8 @@ sub table {
     my @table;
 
     my %attr = %{ delete($params{attr}) // {} };
+    $attr{id} = delete $params{id};
+    $attr{class} = delete $params{class};
 
     my $attr = keys %attr
       ?  join q{ }, '', map { qq{$_="$attr{$_}"} } grep defined( $attr{$_} ), keys %attr
@@ -353,6 +355,15 @@ results in
 =item * attr
 
 Optional. Hash.  The hash elements are added as attributes to the C<table> tag.
+
+=item * id
+
+Optional. Scalar.  The table tag's I<id> attribute.
+
+=item * class
+
+Optional. Scalar.  The table tag's I<class> attribute.
+
 
 =back
 

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -33,6 +33,9 @@ sub table {
       keys %attr
       : '';
 
+    # set all rows bottom_border if requested.
+    my $bottom_border_rows = delete($params{separate_rows});
+
     push @table, "<table$attr>\n";
 
     if ( defined( my $caption = delete $params{caption} ) ) {
@@ -173,7 +176,7 @@ sub table {
                 # any cell in the row has it set. once the attribute is set,
                 # no need to do the check again.
                 $bottom_border //=
-                  ( $cell->{bottom_border} || undef )
+                  ( $bottom_border_rows || $cell->{bottom_border} || undef )
                   && " class=has_bottom_border";
 
                 if ( defined $cell->{raw_html} ) {
@@ -295,7 +298,7 @@ C<align>,
 C<bottom_border>,
 C<colspan>,
 C<html_class>,
-C<html_elemen>,
+C<html_element>,
 C<html_headers>,
 C<html_id>,
 C<html_scope>,
@@ -305,6 +308,9 @@ C<rowspan>
 
 The C<html_element> attribute specifies the name of the HTML element
 to use for that cell. It defaults to C<th> for header rows and C<td> for data rows.
+
+If the C<bottom_border> attribute is set, the row element will have a
+class attribute of C<has_bottom_border>.
 
 For example,
 
@@ -348,6 +354,11 @@ If the footer rows are the last rows in C<rows>, set C<footer_row> to
 the I<negative> number of rows.
 
 =back
+
+=item * separate_rows
+
+Boolean. Optional. Default 0.  If set to true is equivalent to
+setting the C<bottom_border> attribute for each row.
 
 =item * html_colgroup
 

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -55,6 +55,7 @@ sub table {
 
         for my $cell (@$row) {
 
+            my $celltag = $coltag;
             my $text;
             my $attr = '';
 
@@ -79,13 +80,15 @@ sub table {
                 $attr .= " colspan=$colspan" if $colspan > 1;
 
                 $attr .= ' align="' . $cell->{align} . '"' if defined $cell->{align};
+
+                $celltag = $cell->{tag} if defined $cell->{tag};
             }
             else {
                 $text = _encode( $cell // '' );
             }
 
             push @row,
-              '<' . $coltag . $attr . '>', $text, '</' . $coltag . '>';
+              '<' . $celltag . $attr . '>', $text, '</' . $celltag . '>';
 	}
 
         push @table,
@@ -162,7 +165,20 @@ Required. Array of array of (scalars or hashrefs). One or more rows of data,
 where each row is an array reference. And each array element is a string (cell
 content) or hashref (with key C<text> to contain the cell text or C<raw_html> to
 contain the cell's raw HTML which won't be escaped further), and optionally
-other attributes: C<rowspan>, C<colspan>, C<align>, C<bottom_border>).
+other attributes: C<rowspan>, C<colspan>, C<align>, C<bottom_border>, C<tag>).
+
+The C<tag> attribute specifies the tag to use for that cell.  For example,
+
+  header_row => 1,
+  rows =>
+    [ [ '&nbsp', 'January', 'December' ],
+      [ { tag => 'th', text => 'Boots' } , 20, 30 ],
+      [ { tag => 'th', text => 'Frocks' } , 40, 50 ],
+    ]
+
+generates a table where each element in the first row is a header
+element, and the first element in subsequent rows is an element.
+
 
 =item * caption
 

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -293,9 +293,26 @@ Optional. Integer. Default 0. Whether we should add header row(s) (rows inside
 C<< <thead> >> instead of C<< <tbody> >>). Support multiple header rows; you can
 set this argument to an integer larger than 1.
 
-=item * attr
+=item * footer_row
 
-Optional. Hash.  The hash elements are added as attributes to the C<table> tag.
+Optional. Integer. Default 0. Whether we should add footer row(s)
+(rows inside C<< <tfoot> >> instead of C<< <tbody> >>). Supports
+multiple footer rows.
+
+
+=over
+
+=item *
+
+If the footer rows are found immediately after the header rows (if
+any) in the C<rows> array, set C<footer_row> to the number of rows.
+
+=item *
+
+If the footer rows are the last rows in C<rows>, set C<footer_row> to
+the I<negative> number of rows.
+
+=back
 
 =item * colgroup
 
@@ -319,27 +336,9 @@ results in
   <col class="batman" />
   </colgroup>
 
-=item * footer_row
+=item * attr
 
-Optional. Integer. Default 0. Whether we should add footer row(s)
-(rows inside C<< <tfoot> >> instead of C<< <tbody> >>). Supports
-multiple footer rows.
-
-
-=over
-
-=item *
-
-If the footer rows are found immediately after the header rows (if
-any) in the C<rows> array, set C<footer_row> to the number of rows.
-
-=item *
-
-If the footer rows are the last rows in C<rows>, set C<footer_row> to
-the I<negative> number of rows.
-
-=back
-
+Optional. Hash.  The hash elements are added as attributes to the C<table> tag.
 
 =back
 

--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -9,6 +9,11 @@ use warnings;
 # DIST
 # VERSION
 
+sub _croak {
+    require Carp;
+    goto &Carp::croak;
+}
+
 sub _encode {
     state $load = do { require HTML::Entities };
     HTML::Entities::encode_entities(shift);
@@ -81,7 +86,15 @@ sub table {
 
                 $attr .= ' align="' . $cell->{align} . '"' if defined $cell->{align};
 
+
                 $celltag = $cell->{tag} if defined $cell->{tag};
+
+                if ( defined $cell->{scope} ) {
+                    _croak( "'scope' attribute is only valid in header cells" )
+                      unless $coltag eq 'th';
+                    $attr .= ' scope="' . $cell->{scope} . '"'
+                }
+                $attr .= ' style="' . $cell->{style} . '"' if defined $cell->{style};
             }
             else {
                 $text = _encode( $cell // '' );
@@ -165,7 +178,7 @@ Required. Array of array of (scalars or hashrefs). One or more rows of data,
 where each row is an array reference. And each array element is a string (cell
 content) or hashref (with key C<text> to contain the cell text or C<raw_html> to
 contain the cell's raw HTML which won't be escaped further), and optionally
-other attributes: C<rowspan>, C<colspan>, C<align>, C<bottom_border>, C<tag>).
+other attributes: C<rowspan>, C<colspan>, C<align>, C<style>, C<scope>, C<bottom_border>, C<tag>).
 
 The C<tag> attribute specifies the tag to use for that cell.  For example,
 
@@ -178,7 +191,6 @@ The C<tag> attribute specifies the tag to use for that cell.  For example,
 
 generates a table where each element in the first row is a header
 element, and the first element in subsequent rows is an element.
-
 
 =item * caption
 

--- a/t/attr.t
+++ b/t/attr.t
@@ -1,0 +1,31 @@
+#! perl
+
+use Test2::V0;
+use Text::Table::HTML;
+
+*table = \&Text::Table::HTML::table;
+
+is( table( attr => { style => 'border: 3px solid purple;',  },
+           rows => [ [ 1..2 ],
+                 ] ), <<'EOS', 'table attr' );
+<table style="border: 3px solid purple;">
+<tbody>
+<tr><td>1</td><td>2</td></tr>
+</tbody>
+</table>
+EOS
+
+
+is( table( header_row => 1,
+           rows => [ [ { text => 'text', align => 'left', scope => 'col', style => "timeless" }  ],
+                 ] ), <<'EOS', 'cell attr' );
+<table>
+<thead>
+<tr><th align="left" scope="col" style="timeless">text</th></tr>
+</thead>
+<tbody>
+</tbody>
+</table>
+EOS
+
+done_testing;

--- a/t/attr.t
+++ b/t/attr.t
@@ -5,7 +5,7 @@ use Text::Table::HTML;
 
 *table = \&Text::Table::HTML::table;
 
-is( table( attr => { style => 'border: 3px solid purple;',  },
+is( table( html_attr => { style => 'border: 3px solid purple;',  },
            rows => [ [ 1..2 ],
                  ] ), <<'EOS', 'table attr' );
 <table style="border: 3px solid purple;">
@@ -17,7 +17,7 @@ EOS
 
 
 is( table( header_row => 1,
-           rows => [ [ { text => 'text', align => 'left', scope => 'col', style => "timeless" }  ],
+           rows => [ [ { text => 'text', align => 'left', html_scope => 'col', html_style => "timeless" }  ],
                  ] ), <<'EOS', 'cell attr' );
 <table>
 <thead>

--- a/t/bottom_border.t
+++ b/t/bottom_border.t
@@ -5,9 +5,16 @@ use Text::Table::HTML;
 
 *table = \&Text::Table::HTML::table;
 
-is( table( rows => [ [  { text => 'TD11' }, { text => 'TD12', bottom_border => 1 } ],
-                     [ 'TD21'  ],
-                 ] ), <<'EOS', 'rowspan' );
+subtest cell => sub {
+
+    is(
+        table(
+            rows => [
+                [ { text => 'TD11' }, { text => 'TD12', bottom_border => 1 } ],
+                ['TD21'],
+            ]
+        ),
+        <<'EOS', 'rowspan' );
 <table>
 <tbody>
 <tr class=has_bottom_border><td>TD11</td><td>TD12</td></tr>
@@ -15,5 +22,28 @@ is( table( rows => [ [  { text => 'TD11' }, { text => 'TD12', bottom_border => 1
 </tbody>
 </table>
 EOS
+
+};
+
+subtest 'all rows' => sub {
+
+    is(
+        table(
+            rows => [
+                [ { text => 'TD11' }, { text => 'TD12' } ],
+                ['TD21'],
+            ],
+            separate_rows => 1,
+        ),
+        <<'EOS', 'rowspan' );
+<table>
+<tbody>
+<tr class=has_bottom_border><td>TD11</td><td>TD12</td></tr>
+<tr><td>TD21</td></tr>
+</tbody>
+</table>
+EOS
+
+};
 
 done_testing;

--- a/t/colgroup.t
+++ b/t/colgroup.t
@@ -1,0 +1,31 @@
+#! perl
+
+use Test2::V0;
+
+use Text::Table::HTML;
+
+*table = \&Text::Table::HTML::table;
+
+sub rows {
+    [
+        [ 1..5 ],
+    ]
+}
+
+is ( table( rows => rows(),
+            colgroup => [ undef, {}, q{span="2"}, { class => 'batman' } ]
+        ), <<'EOS', 'no header' );
+<table>
+<colgroup>
+<col />
+<col />
+<col span="2" />
+<col class="batman" />
+</colgroup>
+<tbody>
+<tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr>
+</tbody>
+</table>
+EOS
+
+done_testing;

--- a/t/colgroup.t
+++ b/t/colgroup.t
@@ -13,7 +13,7 @@ sub rows {
 }
 
 is ( table( rows => rows(),
-            colgroup => [ undef, {}, q{span="2"}, { class => 'batman' } ]
+            html_colgroup => [ undef, {}, q{span="2"}, { class => 'batman' } ]
         ), <<'EOS', 'no header' );
 <table>
 <colgroup>

--- a/t/coltag.t
+++ b/t/coltag.t
@@ -1,0 +1,17 @@
+#! perl
+
+use Test2::V0;
+use Text::Table::HTML;
+
+*table = \&Text::Table::HTML::table;
+
+is( table( rows => [ [  { tag => 'th', text => 'TD11' }, { text => 'TD12' } ],
+                 ] ), <<'EOS', 'coltag' );
+<table>
+<tbody>
+<tr><th>TD11</th><td>TD12</td></tr>
+</tbody>
+</table>
+EOS
+
+done_testing;

--- a/t/coltag.t
+++ b/t/coltag.t
@@ -5,7 +5,7 @@ use Text::Table::HTML;
 
 *table = \&Text::Table::HTML::table;
 
-is( table( rows => [ [  { tag => 'th', text => 'TD11' }, { text => 'TD12' } ],
+is( table( rows => [ [  { html_element => 'th', text => 'TD11' }, { text => 'TD12' } ],
                  ] ), <<'EOS', 'coltag' );
 <table>
 <tbody>

--- a/t/footer.t
+++ b/t/footer.t
@@ -1,0 +1,163 @@
+#! perl
+
+use Test2::V0;
+
+use Text::Table::HTML;
+
+*table = \&Text::Table::HTML::table;
+
+sub rows {
+    [
+        [ 'TH11', 'TH12' ],
+        [ 'TH21', 'TH22' ],
+        [ 'TF11', 'TF12' ],
+        [ 'TD11', 'TD12' ],
+        [ 'TD21', 'TD22' ],
+        [ 'TF21', 'TF22' ],
+        [ 'TF31', 'TF32' ],
+    ]
+}
+
+is ( table( rows => rows(),
+            header_row => 0,
+            footer_row => 1,
+        ), <<'EOS', 'no header rows, one front footer row ' );
+<table>
+<tfoot>
+<tr><td>TH11</td><td>TH12</td></tr>
+</tfoot>
+<tbody>
+<tr><td>TH21</td><td>TH22</td></tr>
+<tr><td>TF11</td><td>TF12</td></tr>
+<tr><td>TD11</td><td>TD12</td></tr>
+<tr><td>TD21</td><td>TD22</td></tr>
+<tr><td>TF21</td><td>TF22</td></tr>
+<tr><td>TF31</td><td>TF32</td></tr>
+</tbody>
+</table>
+EOS
+
+is ( table( rows => rows(),
+            header_row => 1,
+        ), <<'EOS', 'one header row' );
+<table>
+<thead>
+<tr><th>TH11</th><th>TH12</th></tr>
+</thead>
+<tbody>
+<tr><td>TH21</td><td>TH22</td></tr>
+<tr><td>TF11</td><td>TF12</td></tr>
+<tr><td>TD11</td><td>TD12</td></tr>
+<tr><td>TD21</td><td>TD22</td></tr>
+<tr><td>TF21</td><td>TF22</td></tr>
+<tr><td>TF31</td><td>TF32</td></tr>
+</tbody>
+</table>
+EOS
+
+is ( table( rows => rows(),
+            header_row => 1,
+            footer_row => 1,
+     ), <<'EOS', 'one header row, one front footer row ' );
+<table>
+<thead>
+<tr><th>TH11</th><th>TH12</th></tr>
+</thead>
+<tfoot>
+<tr><td>TH21</td><td>TH22</td></tr>
+</tfoot>
+<tbody>
+<tr><td>TF11</td><td>TF12</td></tr>
+<tr><td>TD11</td><td>TD12</td></tr>
+<tr><td>TD21</td><td>TD22</td></tr>
+<tr><td>TF21</td><td>TF22</td></tr>
+<tr><td>TF31</td><td>TF32</td></tr>
+</tbody>
+</table>
+EOS
+
+is ( table( rows => rows(),
+            header_row => 2,
+            footer_row => 1,
+     ), <<'EOS', 'two header rows, one front footer row ' );
+<table>
+<thead>
+<tr><th>TH11</th><th>TH12</th></tr>
+<tr><th>TH21</th><th>TH22</th></tr>
+</thead>
+<tfoot>
+<tr><td>TF11</td><td>TF12</td></tr>
+</tfoot>
+<tbody>
+<tr><td>TD11</td><td>TD12</td></tr>
+<tr><td>TD21</td><td>TD22</td></tr>
+<tr><td>TF21</td><td>TF22</td></tr>
+<tr><td>TF31</td><td>TF32</td></tr>
+</tbody>
+</table>
+EOS
+
+is ( table( rows => rows(),
+            header_row => 2,
+            footer_row => 2,
+     ), <<'EOS', 'two header rows, two front footer rows' );
+<table>
+<thead>
+<tr><th>TH11</th><th>TH12</th></tr>
+<tr><th>TH21</th><th>TH22</th></tr>
+</thead>
+<tfoot>
+<tr><td>TF11</td><td>TF12</td></tr>
+<tr><td>TD11</td><td>TD12</td></tr>
+</tfoot>
+<tbody>
+<tr><td>TD21</td><td>TD22</td></tr>
+<tr><td>TF21</td><td>TF22</td></tr>
+<tr><td>TF31</td><td>TF32</td></tr>
+</tbody>
+</table>
+EOS
+
+is ( table( rows => rows(),
+            header_row => 2,
+            footer_row => -1,
+     ), <<'EOS', 'two header rows, one trailing footer row' );
+<table>
+<thead>
+<tr><th>TH11</th><th>TH12</th></tr>
+<tr><th>TH21</th><th>TH22</th></tr>
+</thead>
+<tbody>
+<tr><td>TF11</td><td>TF12</td></tr>
+<tr><td>TD11</td><td>TD12</td></tr>
+<tr><td>TD21</td><td>TD22</td></tr>
+<tr><td>TF21</td><td>TF22</td></tr>
+</tbody>
+<tfoot>
+<tr><td>TF31</td><td>TF32</td></tr>
+</tfoot>
+</table>
+EOS
+
+is ( table( rows => rows(),
+            header_row => 2,
+            footer_row => -2,
+     ), <<'EOS', 'two header rows, two trailing footer rows' );
+<table>
+<thead>
+<tr><th>TH11</th><th>TH12</th></tr>
+<tr><th>TH21</th><th>TH22</th></tr>
+</thead>
+<tbody>
+<tr><td>TF11</td><td>TF12</td></tr>
+<tr><td>TD11</td><td>TD12</td></tr>
+<tr><td>TD21</td><td>TD22</td></tr>
+</tbody>
+<tfoot>
+<tr><td>TF21</td><td>TF22</td></tr>
+<tr><td>TF31</td><td>TF32</td></tr>
+</tfoot>
+</table>
+EOS
+
+done_testing;


### PR DESCRIPTION
- `<table>` element:

   - add direct specification of 'id', 'class', and 'style' attributes
     via the 'id', 'class', and 'style' parameters.

   - Add generic attributes via the 'attr' parameter

   - add `<colgroup>` and `<tfoot>` elements

- table cells:

   - Add 'class', 'header', 'id', 'scope', 'style' attributes

   - allow specification of the type of cell (e.g. 'th' or 'td')
