### PR TITLE
bugfix: cells which tested boolean false (e.g. "0") were not output

### DIFF
--- a/lib/Text/Table/HTML.pm
+++ b/lib/Text/Table/HTML.pm
@@ -232,7 +232,7 @@ sub table {
     push @table, "</tbody>\n" if $needs_tbody_open || $needs_tbody_close;
     push @table, "</table>\n";
 
-    return join( "", grep { $_ } @table );
+    return join( "", @table );
 }
 
 1;

--- a/t/table.t
+++ b/t/table.t
@@ -55,4 +55,14 @@ is( table( rows => [
 </table>
 EOS
 
+is( table( rows => [ [ 'TD11', '0' ],
+                 ] ), <<'EOS', 'cell is "0"' );
+<table>
+<tbody>
+<tr><td>TD11</td><td>0</td></tr>
+</tbody>
+</table>
+EOS
+
+
 done_testing;


### PR DESCRIPTION
When concatenating the strings making up the table,

     join( "",  grep { $_ } @table )

strings which didn't pass the Perl bool truth test were excluded, which included legitimate strings composed of the string "0".

The original code was perhaps designed to skip undefined strings, but that can no longer happen.  Removing the test fixes the bug and makes things a bit faster.